### PR TITLE
Restore network settings menu for multisite

### DIFF
--- a/flush-opcache/admin/class-flush-opcache-admin.php
+++ b/flush-opcache/admin/class-flush-opcache-admin.php
@@ -57,18 +57,19 @@ class Flush_Opcache_Admin {
 	/**
 	 * Generate menu pages in admin area
 	 */
-	public function flush_opcache_admin_menu() {
-		if ( is_multisite() && is_super_admin() && is_main_site() ) {
-			add_management_page(
-				__( 'WP OPcache Settings', 'flush-opcache' ),
-				__( 'WP OPcache', 'flush-opcache' ),
-				'manage_network_options',
-				'flush-opcache',
-				array( $this, 'flush_opcache_admin_page' )
-			);
-		} elseif ( ! is_multisite() && is_admin() ) {
-			add_management_page(
-				__( 'WP OPcache Settings', 'flush-opcache' ),
+        public function flush_opcache_admin_menu() {
+                if ( is_multisite() && is_super_admin() && is_main_site() ) {
+                        add_submenu_page(
+                                'settings.php',
+                                __( 'WP OPcache Settings', 'flush-opcache' ),
+                                __( 'WP OPcache', 'flush-opcache' ),
+                                'manage_network_options',
+                                'flush-opcache',
+                                array( $this, 'flush_opcache_admin_page' )
+                        );
+                } elseif ( ! is_multisite() && is_admin() ) {
+                        add_management_page(
+                                __( 'WP OPcache Settings', 'flush-opcache' ),
 				__( 'WP OPcache', 'flush-opcache' ),
 				'manage_options',
 				'flush-opcache',


### PR DESCRIPTION
## Summary
- ensure the WP OPcache settings page is added to the Network Admin Settings menu when running multisite
- keep the single-site settings page under the Tools menu

## Testing
- php -l flush-opcache/admin/class-flush-opcache-admin.php


------
https://chatgpt.com/codex/tasks/task_b_68cac02793548321a10b54116aadc2d4