### PR TITLE
Handle missing OPcache status response

### DIFF
--- a/flush-opcache/admin/class-flush-opcache-admin.php
+++ b/flush-opcache/admin/class-flush-opcache-admin.php
@@ -311,16 +311,19 @@ class Flush_Opcache_Admin {
 	 */
 	public function flush_opcache_reset() {
 		$opcache_scripts = array();
-		if ( function_exists( 'opcache_get_status' ) ) {
-			try {
-				$raw = opcache_get_status( true );
-				if ( array_key_exists( 'scripts', $raw ) ) {
-					foreach ( $raw['scripts'] as $script ) {
-						/* Remove files outside of WP */
-						if ( false === strpos( $script['full_path'], get_home_path() ) && false === strpos( $script['full_path'], ABSPATH ) ) {
-							continue;
-						}
-						array_push( $opcache_scripts, $script['full_path'] );
+                if ( function_exists( 'opcache_get_status' ) ) {
+                        try {
+                                $raw = opcache_get_status( true );
+                                if ( is_array( $raw ) && isset( $raw['scripts'] ) && is_array( $raw['scripts'] ) ) {
+                                        foreach ( $raw['scripts'] as $script ) {
+                                                if ( ! is_array( $script ) || empty( $script['full_path'] ) ) {
+                                                        continue;
+                                                }
+                                                /* Remove files outside of WP */
+                                                if ( false === strpos( $script['full_path'], get_home_path() ) && false === strpos( $script['full_path'], ABSPATH ) ) {
+                                                        continue;
+                                                }
+                                                array_push( $opcache_scripts, $script['full_path'] );
 					}
 				}
 			} catch ( \Throwable $e ) {


### PR DESCRIPTION
## Summary
- guard against non-array values returned by `opcache_get_status()` before iterating cached scripts
- skip malformed script entries that do not include a `full_path`

## Testing
- `php -l flush-opcache/admin/class-flush-opcache-admin.php`


------
https://chatgpt.com/codex/tasks/task_b_68cac41f1f88832196b65a2d05fd63d2